### PR TITLE
Fix css file path references

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -1,15 +1,15 @@
 @font-face {
     font-family: RoyalWedding;
-    src: url("fonts/RoyalWedding-Regular.otf") format("opentype"),
-         url('fonts/RoyalWedding-regular.woff2') format('woff2'),
-         url('fonts/RoyalWedding-regular.woff') format('woff');
+    src: url("../fonts/RoyalWedding-Regular.otf") format("opentype"),
+         url("../fonts/RoyalWedding-regular.woff2") format("woff2"),
+         url("../fonts/RoyalWedding-regular.woff") format("woff");
 }
 
 @font-face {
     font-family: Quicksand;
-    src: url("fonts/Quicksand_Book.otf") format("opentype"),
-         url('fonts/quicksand_book.woff2') format('woff2'),
-         url('fonts/quicksand_book.woff') format('woff');
+    src: url("../fonts/Quicksand_Book.otf") format("opentype"),
+         url("../fonts/quicksand_book.woff2") format("woff2"),
+         url("../fonts/quicksand_book.woff") format("woff");
 }
 
 * {


### PR DESCRIPTION
The fonts weren't being found earlier because they were hitting the wrong subdirectory, oops.

Screenshot with successful font pull (ignore the navbar, that's on a separate branch):
<img width="882" alt="Screenshot 2024-12-13 at 12 47 15 AM" src="https://github.com/user-attachments/assets/e9f14d4c-4982-42fa-b580-696c5cb6c55c" />
