### PR TITLE
'contain' image instead of 'cover'-ing it

### DIFF
--- a/css/parallax.css
+++ b/css/parallax.css
@@ -9,5 +9,5 @@
     background-attachment: fixed;
     background-position: center;
     background-repeat: no-repeat;
-    background-size: cover;
+    background-size: contain;
 }


### PR DESCRIPTION
Before:
<img width="1680" alt="Screenshot 2024-12-15 at 2 43 22 AM" src="https://github.com/user-attachments/assets/8e9c300a-49f6-4ed5-96dc-1e11840ef24b" />

After:
<img width="1670" alt="Screenshot 2024-12-15 at 2 43 41 AM" src="https://github.com/user-attachments/assets/3fc8f0a1-fde6-4637-8464-b280f14f45f8" />

Hoping to make the mobile experience a little better, but I might revert this PR if it still looks shitty on mobile; web is more impactful with `cover`.