### PR TITLE
Fixing mobile css for parallax

### DIFF
--- a/css/parallax.css
+++ b/css/parallax.css
@@ -1,3 +1,5 @@
+/* Web - for the most part */
+@media screen and (min-width:1000px) {
 .parallax {
     /* Be sure to set the background-image in the html source code. */
     /* Example: style="background-image: url('photos/stalker_shot.jpeg');" */
@@ -10,4 +12,17 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
+}
+}
+
+/* Mobile - for the most part */
+@media screen and (max-width:980px) {
+    /* On mobile, we simply insert the image (parallax doesn't work on iOS) */
+    .parallax {
+        /* Be sure to set the background-image in the html source code. */
+        /* Example: style="background-image: url('photos/stalker_shot.jpeg');" */
+
+        /* Full height */
+        height: 100%;
+    }
 }


### PR DESCRIPTION
Looks like although the parallax scroll works on Android, it does not work on iOS (checked Safari and Chrome). This diff (verified on David's and my phones) makes it so that if your screen size is smaller, we don't do the parallax scroll.

This isn't perfect - not everyones resolutions will fall into these buckets, and even on web if you make your screen smaller the css will change, but it's good enough.