### PR TITLE
Flexboxes get a 15% margin on the sides

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -29,6 +29,8 @@ section {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    margin-left: 15%;
+    margin-right: 15%;
 }
 
 h1 {


### PR DESCRIPTION
Text looks cleaner this way.

Before:
<img width="1645" alt="Screenshot 2025-01-03 at 9 38 42 PM" src="https://github.com/user-attachments/assets/7ce945ab-959b-4a4d-bb69-24741905d7a6" />

After:
<img width="1511" alt="Screenshot 2025-01-03 at 9 38 57 PM" src="https://github.com/user-attachments/assets/0e0997de-b863-4f6d-8eaf-cb1faa046c3d" />
