### PR TITLE
Fix margin in navbar to match browser default

### DIFF
--- a/css/navbar.css
+++ b/css/navbar.css
@@ -28,7 +28,10 @@ ul.nav {
     background-color: #da8442;
     position: fixed;
     top:0px;
-    width: 100%;
+    left: 0;
+    right: 0;
+    margin-left:8px;
+    margin-right:8px;
     height:40px;
 }
 


### PR DESCRIPTION
Before:
<img width="1068" alt="Screenshot 2025-03-07 at 7 04 28 PM" src="https://github.com/user-attachments/assets/1f88a02f-a9ea-49dc-88ee-2d296bc60c98" />


After:
<img width="1064" alt="Screenshot 2025-03-07 at 7 04 10 PM" src="https://github.com/user-attachments/assets/ffd4649a-8ffe-45ee-a067-8a1c70350b6b" />
